### PR TITLE
Update profile page to wrap text responsively

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,93 +12,150 @@
       color: #fff;
       overflow: hidden;
     }
-    .profile {
-      position: absolute;
-      top: 20px;
-      left: 20px;
-      animation: fadeIn 2s ease-in-out;
-      max-width: 300px;
-      line-height: 1.5;
-    }
-    .skills {
-      position: absolute;
-      top: 160px;
-      left: 20px;
-      line-height: 1.5;
-    }
-    .skill-label {
-      position: absolute;
-      left: 0;
-      margin-bottom: 20px;
-    }
-    @keyframes fadeIn {
-      from { opacity: 0; }
-      to { opacity: 1; }
-    }
     canvas {
       display: block;
     }
-  </style>
-</head>
-<body>
-  <div class="profile">
-    <h1>React Architect</h1>
-    <p><strong>Name:</strong> Jane Doe</p>
-    <p><strong>Experience:</strong> 18 years crafting scalable React applications and leading development teams.</p>
-    <p>Passionate about building performant user interfaces and exploring the latest in web technologies.</p>
-  </div>
-  <div class="skills" id="skills"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-  <script>
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
-    renderer.setSize(window.innerWidth, window.innerHeight);
-    document.body.appendChild(renderer.domElement);
-
-    camera.position.set(0, 0, 5);
-
-    const skillsData = [
-      { name: 'JavaScript', years: 6 },
-      { name: 'React', years: 5 },
-      { name: 'Node.js', years: 4 },
-      { name: 'CSS', years: 7 }
-    ];
-
-    const radius = 0.1;
-    const spacing = 0.6;
-    const scale = 0.4; // length per year
-
-    const skillsContainer = document.getElementById('skills');
-
-    skillsData.forEach((skill, index) => {
-      const length = skill.years * scale;
-      const geometry = new THREE.CylinderGeometry(radius, radius, length, 32);
-      const material = new THREE.MeshNormalMaterial();
-      const bar = new THREE.Mesh(geometry, material);
-      bar.rotation.z = Math.PI / 2;
-      bar.position.y = -index * spacing;
-      bar.position.x = length / 2;
-      scene.add(bar);
-
-      const label = document.createElement('div');
-      label.className = 'skill-label';
-      label.textContent = `${skill.name} - ${skill.years} yrs`;
-      label.style.top = `${index * 20}px`;
-      skillsContainer.appendChild(label);
-    });
-
-    function animate() {
-      requestAnimationFrame(animate);
-      renderer.render(scene, camera);
-    }
-    animate();
-
-    window.addEventListener('resize', () => {
-      camera.aspect = window.innerWidth / window.innerHeight;
-      camera.updateProjectionMatrix();
+    </style>
+  </head>
+  <body>
+    <!-- All content will be rendered inside the canvas using Three.js -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script>
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+      const renderer = new THREE.WebGLRenderer({ antialias: true });
       renderer.setSize(window.innerWidth, window.innerHeight);
-    });
+      document.body.appendChild(renderer.domElement);
+
+      camera.position.set(0, 0, 5);
+
+      function createWrappedTextSprite(message, opts = {}) {
+        const {
+          color = '#fff',
+          font = '24px Arial',
+          maxWidth = 300
+        } = opts;
+
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        ctx.font = font;
+        ctx.fillStyle = color;
+        ctx.textBaseline = 'top';
+
+        const words = message.split(' ');
+        const lineHeight = parseInt(font, 10) * 1.2;
+        let line = '';
+        const lines = [];
+
+        words.forEach(word => {
+          const test = line + word + ' ';
+          if (ctx.measureText(test).width > maxWidth && line !== '') {
+            lines.push(line);
+            line = word + ' ';
+          } else {
+            line = test;
+          }
+        });
+        lines.push(line);
+
+        const textWidth = maxWidth;
+        const textHeight = lines.length * lineHeight;
+        canvas.width = textWidth;
+        canvas.height = textHeight;
+        ctx.font = font;
+        ctx.fillStyle = color;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+
+        lines.forEach((ln, i) => {
+          ctx.fillText(ln.trim(), 0, i * lineHeight);
+        });
+
+        const texture = new THREE.CanvasTexture(canvas);
+        const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+        const sprite = new THREE.Sprite(material);
+        sprite.scale.set(textWidth / 100, textHeight / 100, 1);
+        sprite.userData = { message, opts: { color, font, maxWidth }, lineHeight: textHeight / 100 };
+        return sprite;
+      }
+
+      function maxTextWidth() {
+        return Math.min(window.innerWidth - 40, 300);
+      }
+
+      let profileSprites = [];
+      let skillSprites = [];
+
+      function renderProfile() {
+        profileSprites.forEach(s => scene.remove(s));
+        profileSprites = [];
+        let profileY = 2;
+        profileLines.forEach((line, i) => {
+          const font = i === 0 ? '30px Arial' : '20px Arial';
+          const sprite = createWrappedTextSprite(line, { font, maxWidth: maxTextWidth() });
+          sprite.position.set(-2, profileY, 0);
+          profileY -= sprite.userData.lineHeight + 0.1;
+          scene.add(sprite);
+          profileSprites.push(sprite);
+        });
+      }
+
+      function renderSkills() {
+        skillSprites.forEach(s => scene.remove(s));
+        skillSprites = [];
+        skillsData.forEach((skill, index) => {
+          const label = createWrappedTextSprite(`${skill.name} - ${skill.years} yrs`, { font: '20px Arial', maxWidth: maxTextWidth() });
+          label.position.set(-1.5, -index * spacing - 1, 0);
+          scene.add(label);
+          skillSprites.push(label);
+        });
+      }
+
+      const profileLines = [
+        'React Architect',
+        'Name: Jane Doe',
+        'Experience: 18 years crafting scalable React applications and leading development teams.',
+        'Passionate about building performant user interfaces and exploring the latest in web technologies.'
+      ];
+
+      const skillsData = [
+        { name: 'JavaScript', years: 6 },
+        { name: 'React', years: 5 },
+        { name: 'Node.js', years: 4 },
+        { name: 'CSS', years: 7 }
+      ];
+
+      const radius = 0.1;
+      const spacing = 0.6;
+      const scale = 0.4; // length per year
+
+      skillsData.forEach((skill, index) => {
+        const length = skill.years * scale;
+        const geometry = new THREE.CylinderGeometry(radius, radius, length, 32);
+        const material = new THREE.MeshNormalMaterial();
+        const bar = new THREE.Mesh(geometry, material);
+        bar.rotation.z = Math.PI / 2;
+        bar.position.y = -index * spacing - 1;
+        bar.position.x = length / 2;
+        scene.add(bar);
+      });
+
+      renderProfile();
+      renderSkills();
+
+      function animate() {
+        requestAnimationFrame(animate);
+        renderer.render(scene, camera);
+      }
+      animate();
+
+      window.addEventListener('resize', () => {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderProfile();
+        renderSkills();
+      });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render profile and skills labels inside canvas using a wrapped text helper
- recreate text sprites when the window resizes for responsive layout
- keep all labels left aligned and prevent overflow

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684acf16abc8832fb6cbe6df2bb6664a